### PR TITLE
check result from redis.Redis.get() before escaping

### DIFF
--- a/app.py
+++ b/app.py
@@ -35,7 +35,8 @@ def create():
         generated = True
     else:
         generated = False
-    r.set(key, secret)
+    while not r.setnx(key, secret):
+        key = random_string(redis_key_length)
     secret_url = "%s/get/%s" % (host, key)
 
     if generated:
@@ -57,9 +58,9 @@ def generate():
 
 @app.route("/get/<key>")
 def retrieve(key=None):
-    secret = (r.get(key)
+    secret = r.get(key)
     r.delete(key)
-    if type(secret) == types.StringType:
+    if type(secret) != types.NoneType:
         secret = escape(secret)
     return render_template('get.tmpl', secret=secret)
 

--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ import redis
 import random
 import string
 import os
+import types
 
 host = "https://secrets-accp.mendix.com"
 r = redis.Redis()
@@ -56,8 +57,10 @@ def generate():
 
 @app.route("/get/<key>")
 def retrieve(key=None):
-    secret = escape(r.get(key))
+    secret = (r.get(key)
     r.delete(key)
+    if type(secret) == types.StringType:
+        secret = escape(secret)
     return render_template('get.tmpl', secret=secret)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Check that redis returned a value before escaping it. Otherwise None gets cast to the string "None" and get.tmpl spits that out.
